### PR TITLE
Gradle 6.x support

### DIFF
--- a/src/main/groovy/com/zlad/gradle/avrohugger/AvrohuggerExtension.groovy
+++ b/src/main/groovy/com/zlad/gradle/avrohugger/AvrohuggerExtension.groovy
@@ -5,13 +5,14 @@ import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.util.ConfigureUtil
 
 class AvrohuggerExtension implements CustomTypesValues, SourceFormatValues {
     final ConfigurableFileCollection sourceDirectories
     final DirectoryProperty destinationDirectory
-    final Property<Map<String, String>> namespaceMapping
+    final MapProperty<String, String> namespaceMapping
     final Property<CustomTypes> typeMapping
     final Property<ScalaSourceFormat> sourceFormat
 
@@ -19,13 +20,13 @@ class AvrohuggerExtension implements CustomTypesValues, SourceFormatValues {
         sourceDirectories = project.files()
         sourceDirectories.setFrom(project.files('src/main/avro'))
 
-        destinationDirectory = project.layout.directoryProperty()
+        destinationDirectory = project.objects.directoryProperty()
         destinationDirectory.set(project.file("${project.buildDir}/generated-src/avro"))
 
         typeMapping = project.objects.property(CustomTypes)
         typeMapping.set(new CustomTypes())
 
-        namespaceMapping = project.objects.property(Map)
+        namespaceMapping = project.objects.mapProperty(String,String)
         namespaceMapping.set([:])
 
         sourceFormat = project.objects.property(ScalaSourceFormat)

--- a/src/main/groovy/com/zlad/gradle/avrohugger/GenerateScalaTask.groovy
+++ b/src/main/groovy/com/zlad/gradle/avrohugger/GenerateScalaTask.groovy
@@ -2,6 +2,7 @@ package com.zlad.gradle.avrohugger
 
 import avrohugger.types.AvroScalaTypes
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -23,13 +24,13 @@ class GenerateScalaTask extends SourceTask {
     private final WorkerExecutor workerExecutor
 
     @OutputDirectory
-    final DirectoryProperty destinationDir = project.layout.directoryProperty()
+    final DirectoryProperty destinationDir = project.objects.directoryProperty()
 
     @Input
     final Property<AvroScalaTypes> customTypes =  project.objects.property(AvroScalaTypes)
 
     @Input
-    final Property<Map<String, String>> customNamespaces = project.objects.property(Map)
+    final MapProperty<String, String> customNamespaces = project.objects.mapProperty(String,String)
 
     @Input
     final Property<ScalaSourceFormat> sourceFormat =  project.objects.property(ScalaSourceFormat)


### PR DESCRIPTION
Why:

Deprecated methods used were removed in Gradle 6.x

Using the plugin in a project with Gradle 6.x fails with the message:
* What went wrong:
An exception occurred applying plugin request [id: 'com.zlad.gradle.avrohugger', version: '0.2.5']
> Failed to apply plugin [id 'com.zlad.gradle.avrohugger']
   > Could not create an instance of type com.zlad.gradle.avrohugger.AvrohuggerExtension.
      > No signature of method: org.gradle.api.internal.file.DefaultProjectLayout.directoryProperty() is applicable for argument types: () values: []

This is due to https://docs.gradle.org/6.0-rc-3/userguide/upgrading_version_5.html#replaced_and_removed_apis 

* Replaced DefaultDirectory.layout.directoryProperty with ObjectFactory and Mapped properties with project.objects.mapProperty.