### PR TITLE
Upgrade to Scala 2.13

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # main versions
-scalaBinaryVersion=2.12
+scalaBinaryVersion=2.13
 avrohuggerVersion=2.12.0
 
 # test versions

--- a/src/main/groovy/com/zlad/gradle/avrohugger/ScalaConversions.groovy
+++ b/src/main/groovy/com/zlad/gradle/avrohugger/ScalaConversions.groovy
@@ -6,8 +6,8 @@ import scala.collection.JavaConverters$
 class ScalaConversions {
 
     static <K, V> scala.collection.immutable.Map<K, V> convert(Map<K, V> map) {
-        return JavaConverters$.MODULE$.mapAsScalaMapConverter(map).asScala().toMap(
-                scala.Predef$.MODULE$.<scala.Tuple2<K, V>>conforms()
+        return scala.collection.immutable.Map$.MODULE$.from(
+                JavaConverters$.MODULE$.mapAsScalaMapConverter(map).asScala()
         )
     }
 }


### PR DESCRIPTION
It is becoming impossible to use this plugin with other plugins as they are all upgrading to Scala 2.13. Using plugins with a mix of Scala 2.12 and 2.13 introduces a binary incompatibility.

fixes #8 